### PR TITLE
Fix typo in ratelimit popup

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -40,7 +40,7 @@ export default async function handler(
     if (!result.success) {
       res
         .status(429)
-        .json("Too many uploads in 1 day. Please try again in a 24 hours.");
+        .json("Too many uploads in 1 day. Please try again in 24 hours.");
       return;
     }
   }


### PR DESCRIPTION
Fixed a typo in the alert which pops up when the user exceeds their requests allowance.