### PR TITLE
Avoid creating duplicate credits

### DIFF
--- a/pages/api/stripe-webhook.ts
+++ b/pages/api/stripe-webhook.ts
@@ -47,7 +47,6 @@ const webhookHandler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // Cast event data to Stripe object.
     if (
-      event.type === "payment_intent.succeeded" ||
       event.type === "checkout.session.completed"
     ) {
       const paymentIntent = event.data.object as Stripe.PaymentIntent;


### PR DESCRIPTION
Both events are fired ("payment_intent.succeeded", "checkout.session.completed") in a successful interaction. They behave like a state machine not exclusionary.