### PR TITLE
Upgrade: react-uploader -> @bytescale/upload-widget-react

### DIFF
--- a/app/dream/page.tsx
+++ b/app/dream/page.tsx
@@ -15,6 +15,7 @@ import downloadPhoto from "../../utils/downloadPhoto";
 import DropDown from "../../components/DropDown";
 import { roomType, rooms, themeType, themes } from "../../utils/dropdownTypes";
 import {UploadWidgetConfig} from "@bytescale/upload-widget";
+import {UrlBuilder} from "@bytescale/sdk";
 
 const options: UploadWidgetConfig = {
   apiKey: !!process.env.NEXT_PUBLIC_UPLOAD_API_KEY
@@ -54,11 +55,21 @@ export default function DreamPage() {
   const UploadDropZone = () => (
     <UploadDropzone
       options={options}
-      onUpdate={(file) => {
-        if (file.length !== 0) {
-          setPhotoName(file[0].originalFile.originalFileName);
-          setOriginalPhoto(file[0].fileUrl.replace("raw", "thumbnail"));
-          generatePhoto(file[0].fileUrl.replace("raw", "thumbnail"));
+      onUpdate={(files) => {
+        if (files.length !== 0) {
+          const image = files[0];
+          const imageName = image.originalFile.originalFileName
+          const imageUrl = UrlBuilder.url({
+            accountId: image.originalFile.accountId,
+            filePath: image.filePath,
+            options: {
+              transformation: "preset",
+              transformationPreset: "thumbnail"
+            }
+          });
+          setPhotoName(imageName);
+          setOriginalPhoto(imageUrl);
+          generatePhoto(imageUrl);
         }
       }}
       width="670px"

--- a/app/dream/page.tsx
+++ b/app/dream/page.tsx
@@ -3,6 +3,8 @@
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import { useState } from "react";
+import { UrlBuilder } from "@bytescale/sdk";
+import { UploadWidgetConfig } from "@bytescale/upload-widget";
 import { UploadDropzone } from "@bytescale/upload-widget-react";
 import { CompareSlider } from "../../components/CompareSlider";
 import Footer from "../../components/Footer";
@@ -14,8 +16,6 @@ import appendNewToName from "../../utils/appendNewToName";
 import downloadPhoto from "../../utils/downloadPhoto";
 import DropDown from "../../components/DropDown";
 import { roomType, rooms, themeType, themes } from "../../utils/dropdownTypes";
-import {UploadWidgetConfig} from "@bytescale/upload-widget";
-import {UrlBuilder} from "@bytescale/sdk";
 
 const options: UploadWidgetConfig = {
   apiKey: !!process.env.NEXT_PUBLIC_UPLOAD_API_KEY
@@ -55,12 +55,12 @@ export default function DreamPage() {
   const UploadDropZone = () => (
     <UploadDropzone
       options={options}
-      onUpdate={(files) => {
-        if (files.length !== 0) {
-          const image = files[0];
-          const imageName = image.originalFile.originalFileName
+      onUpdate={({ uploadedFiles }) => {
+        if (uploadedFiles.length !== 0) {
+          const image = uploadedFiles[0];
+          const imageName = image.originalFile.originalFileName;
           const imageUrl = UrlBuilder.url({
-            accountId: image.originalFile.accountId,
+            accountId: image.accountId,
             filePath: image.filePath,
             options: {
               transformation: "preset",

--- a/app/dream/page.tsx
+++ b/app/dream/page.tsx
@@ -3,8 +3,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import { useState } from "react";
-import { UploadDropzone } from "react-uploader";
-import { Uploader } from "uploader";
+import { UploadDropzone } from "@bytescale/upload-widget-react";
 import { CompareSlider } from "../../components/CompareSlider";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
@@ -15,15 +14,12 @@ import appendNewToName from "../../utils/appendNewToName";
 import downloadPhoto from "../../utils/downloadPhoto";
 import DropDown from "../../components/DropDown";
 import { roomType, rooms, themeType, themes } from "../../utils/dropdownTypes";
+import {UploadWidgetConfig} from "@bytescale/upload-widget";
 
-// Configuration for the uploader
-const uploader = Uploader({
+const options: UploadWidgetConfig = {
   apiKey: !!process.env.NEXT_PUBLIC_UPLOAD_API_KEY
-    ? process.env.NEXT_PUBLIC_UPLOAD_API_KEY
-    : "free",
-});
-
-const options = {
+      ? process.env.NEXT_PUBLIC_UPLOAD_API_KEY
+      : "free",
   maxFileCount: 1,
   mimeTypes: ["image/jpeg", "image/png", "image/jpg"],
   editor: { images: { crop: false } },
@@ -57,7 +53,6 @@ export default function DreamPage() {
 
   const UploadDropZone = () => (
     <UploadDropzone
-      uploader={uploader}
       options={options}
       onUpdate={(file) => {
         if (file.length !== 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@bytescale/upload-widget-react": "^4.1.0",
+        "@bytescale/upload-widget-react": "^4.9.0",
         "@headlessui/react": "^1.7.7",
         "@headlessui/tailwindcss": "^0.1.2",
         "@heroicons/react": "^2.0.16",
@@ -346,14 +346,14 @@
       }
     },
     "node_modules/@bytescale/sdk": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
-      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.4.4.tgz",
+      "integrity": "sha512-spJojkzPGo8Ui6DZYNuVHZZ6O6bZo+U+7WYJ9nZNP+aby0x/G+KRdsh0HlkoB9smE1VK/7c83Xy7IrnStfVfdQ=="
     },
     "node_modules/@bytescale/upload-widget": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
-      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.12.0.tgz",
+      "integrity": "sha512-XHhUHuCSG1wG5JATyhx7XwL6cc8w2xeWis6xPmxohtsRvmOERlSmLLUlEnstn5MyVKOe866+vq5aabZi0HmzYQ==",
       "dependencies": {
         "@bytescale/sdk": "^3.2.0",
         "classnames": "^2.2.6",
@@ -361,11 +361,11 @@
       }
     },
     "node_modules/@bytescale/upload-widget-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
-      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.9.0.tgz",
+      "integrity": "sha512-+j1FhBTcXsKPnC2p0/e0h58HR7uoIoKADeM3LpNikquFq8FJlkOj9eivKR62fbqkI3jRJ2bhjMVyXgPMMPRgJw==",
       "dependencies": {
-        "@bytescale/upload-widget": "^4.6.0",
+        "@bytescale/upload-widget": "^4.12.0",
         "lodash.isequal": "^4.5.0"
       },
       "peerDependencies": {
@@ -2089,9 +2089,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.0.tgz",
-      "integrity": "sha512-ERdIdUpR6doqdaSIh80hvzebHB7O6JxycOhyzAeLEchqOq/4yueslQbfnPwXaNhAYacFTyCclhwkEbOumT0tHw==",
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
+      "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2731,14 +2731,14 @@
       }
     },
     "@bytescale/sdk": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
-      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.4.4.tgz",
+      "integrity": "sha512-spJojkzPGo8Ui6DZYNuVHZZ6O6bZo+U+7WYJ9nZNP+aby0x/G+KRdsh0HlkoB9smE1VK/7c83Xy7IrnStfVfdQ=="
     },
     "@bytescale/upload-widget": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
-      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.12.0.tgz",
+      "integrity": "sha512-XHhUHuCSG1wG5JATyhx7XwL6cc8w2xeWis6xPmxohtsRvmOERlSmLLUlEnstn5MyVKOe866+vq5aabZi0HmzYQ==",
       "requires": {
         "@bytescale/sdk": "^3.2.0",
         "classnames": "^2.2.6",
@@ -2746,11 +2746,11 @@
       }
     },
     "@bytescale/upload-widget-react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
-      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.9.0.tgz",
+      "integrity": "sha512-+j1FhBTcXsKPnC2p0/e0h58HR7uoIoKADeM3LpNikquFq8FJlkOj9eivKR62fbqkI3jRJ2bhjMVyXgPMMPRgJw==",
       "requires": {
-        "@bytescale/upload-widget": "^4.6.0",
+        "@bytescale/upload-widget": "^4.12.0",
         "lodash.isequal": "^4.5.0"
       }
     },
@@ -3835,9 +3835,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "preact": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.0.tgz",
-      "integrity": "sha512-ERdIdUpR6doqdaSIh80hvzebHB7O6JxycOhyzAeLEchqOq/4yueslQbfnPwXaNhAYacFTyCclhwkEbOumT0tHw=="
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
+      "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA=="
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@bytescale/upload-widget-react": "^4.1.0",
         "@headlessui/react": "^1.7.7",
         "@headlessui/tailwindcss": "^0.1.2",
         "@heroicons/react": "^2.0.16",
@@ -18,10 +19,8 @@
         "react-compare-slider": "^2.2.0",
         "react-countup": "^6.4.0",
         "react-dom": "^18.2.0",
-        "react-uploader": "^3.10.0",
         "react-use-measure": "^2.1.1",
-        "request-ip": "^3.3.0",
-        "uploader": "^3.9.0"
+        "request-ip": "^3.3.0"
       },
       "devDependencies": {
         "@types/node": "18.11.3",
@@ -344,6 +343,33 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bytescale/sdk": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+    },
+    "node_modules/@bytescale/upload-widget": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
+      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "dependencies": {
+        "@bytescale/sdk": "^3.2.0",
+        "classnames": "^2.2.6",
+        "preact": "^10.6.5"
+      }
+    },
+    "node_modules/@bytescale/upload-widget-react": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
+      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "dependencies": {
+        "@bytescale/upload-widget": "^4.6.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
       }
     },
     "node_modules/@emotion/is-prop-valid": {
@@ -848,11 +874,6 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
-    },
-    "node_modules/@upload-io/upload-api-client-upload-js": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.15.0.tgz",
-      "integrity": "sha512-UGqT4wxCDhTTKnTLvqtKCyPJSswA2z6/Z6/sMakWGdJBBuwCHcOyXgoWafbPILrgWp3oMMQjnTfwwMBmR0O54w=="
     },
     "node_modules/@upstash/core-analytics": {
       "version": "0.0.5",
@@ -1719,6 +1740,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2071,11 +2097,6 @@
         "url": "https://opencollective.com/preact"
       }
     },
-    "node_modules/progress-smoother": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.4.0.tgz",
-      "integrity": "sha512-ctIG/KF/3DQ1zQHMWbXjcnicggTsEzZEA2JEnJNrPtK88tmqN9cfQf01yfLWGCBF93R5XN1EUe/z/IV5NKrmCw=="
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2148,17 +2169,6 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-uploader": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.10.0.tgz",
-      "integrity": "sha512-X59mBrV8+E8QrGiajvgJodrZbsHxHGxBE1/Ym4FRe6+Oy8V8FcVwc5CVuwiKaJn1wk1tN8ufK62HY93mvz62PQ==",
-      "dependencies": {
-        "uploader": "^3.9.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
       }
     },
     "node_modules/react-use-measure": {
@@ -2427,25 +2437,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/upload-js": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.11.2.tgz",
-      "integrity": "sha512-q6IkwFLA3kL1MbBMvzCbJC0EHjMgjJ399f5QH3Up5rkoVjYXZxTKRgyJQeRT1HpqPQ3gCJdvZuL/Cv1LjBRGMg==",
-      "dependencies": {
-        "@upload-io/upload-api-client-upload-js": "^2.15.0",
-        "progress-smoother": "^1.4.0"
-      }
-    },
-    "node_modules/uploader": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.9.0.tgz",
-      "integrity": "sha512-sv1p4ZFXQReJNsYGBwToREGqh/SsLgmt8mnpluux8ui78vhwSiHt7LOgfRm7iCguYiPQcVS9NsdkJulq4J46qQ==",
-      "dependencies": {
-        "classnames": "^2.2.6",
-        "preact": "^10.6.5",
-        "upload-js": "^2.11.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -2737,6 +2728,30 @@
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@bytescale/sdk": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/sdk/-/sdk-3.2.0.tgz",
+      "integrity": "sha512-8FqAPp1NCffd05aAvKY72A/8/hoVfhTW7nEMccSfngxGCfCnYJBwoZTv4/Qp5jh5XUVAN08vjNKI1LXTt1G1Xw=="
+    },
+    "@bytescale/upload-widget": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget/-/upload-widget-4.7.0.tgz",
+      "integrity": "sha512-QiOYeDAlX4ZcweX0NXm3VSVYRumMdi5qjAEzrFXM4O7ps93Q4gzkT/8/Q9ybGxc+NVWQIew6OBQLweu83bfCOA==",
+      "requires": {
+        "@bytescale/sdk": "^3.2.0",
+        "classnames": "^2.2.6",
+        "preact": "^10.6.5"
+      }
+    },
+    "@bytescale/upload-widget-react": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@bytescale/upload-widget-react/-/upload-widget-react-4.1.0.tgz",
+      "integrity": "sha512-cpz1nVIDwhbbSMnPJyURtT2QqpO55i0kqtO5Bx60AlX9MCaReXOqjn21unIInPxQqs0TxvglBPVCmTqUv4GviA==",
+      "requires": {
+        "@bytescale/upload-widget": "^4.6.0",
+        "lodash.isequal": "^4.5.0"
       }
     },
     "@emotion/is-prop-valid": {
@@ -3062,11 +3077,6 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
-    },
-    "@upload-io/upload-api-client-upload-js": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@upload-io/upload-api-client-upload-js/-/upload-api-client-upload-js-2.15.0.tgz",
-      "integrity": "sha512-UGqT4wxCDhTTKnTLvqtKCyPJSswA2z6/Z6/sMakWGdJBBuwCHcOyXgoWafbPILrgWp3oMMQjnTfwwMBmR0O54w=="
     },
     "@upstash/core-analytics": {
       "version": "0.0.5",
@@ -3624,6 +3634,11 @@
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
       "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg=="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3824,11 +3839,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.0.tgz",
       "integrity": "sha512-ERdIdUpR6doqdaSIh80hvzebHB7O6JxycOhyzAeLEchqOq/4yueslQbfnPwXaNhAYacFTyCclhwkEbOumT0tHw=="
     },
-    "progress-smoother": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/progress-smoother/-/progress-smoother-1.4.0.tgz",
-      "integrity": "sha512-ctIG/KF/3DQ1zQHMWbXjcnicggTsEzZEA2JEnJNrPtK88tmqN9cfQf01yfLWGCBF93R5XN1EUe/z/IV5NKrmCw=="
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3869,14 +3879,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
-      }
-    },
-    "react-uploader": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/react-uploader/-/react-uploader-3.10.0.tgz",
-      "integrity": "sha512-X59mBrV8+E8QrGiajvgJodrZbsHxHGxBE1/Ym4FRe6+Oy8V8FcVwc5CVuwiKaJn1wk1tN8ufK62HY93mvz62PQ==",
-      "requires": {
-        "uploader": "^3.9.0"
       }
     },
     "react-use-measure": {
@@ -4043,25 +4045,6 @@
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
-      }
-    },
-    "upload-js": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/upload-js/-/upload-js-2.11.2.tgz",
-      "integrity": "sha512-q6IkwFLA3kL1MbBMvzCbJC0EHjMgjJ399f5QH3Up5rkoVjYXZxTKRgyJQeRT1HpqPQ3gCJdvZuL/Cv1LjBRGMg==",
-      "requires": {
-        "@upload-io/upload-api-client-upload-js": "^2.15.0",
-        "progress-smoother": "^1.4.0"
-      }
-    },
-    "uploader": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/uploader/-/uploader-3.9.0.tgz",
-      "integrity": "sha512-sv1p4ZFXQReJNsYGBwToREGqh/SsLgmt8mnpluux8ui78vhwSiHt7LOgfRm7iCguYiPQcVS9NsdkJulq4J46qQ==",
-      "requires": {
-        "classnames": "^2.2.6",
-        "preact": "^10.6.5",
-        "upload-js": "^2.11.0"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@bytescale/upload-widget-react": "^4.1.0",
     "@headlessui/react": "^1.7.7",
     "@headlessui/tailwindcss": "^0.1.2",
     "@heroicons/react": "^2.0.16",
@@ -19,10 +20,8 @@
     "react-compare-slider": "^2.2.0",
     "react-countup": "^6.4.0",
     "react-dom": "^18.2.0",
-    "react-uploader": "^3.10.0",
     "react-use-measure": "^2.1.1",
-    "request-ip": "^3.3.0",
-    "uploader": "^3.9.0"
+    "request-ip": "^3.3.0"
   },
   "devDependencies": {
     "@types/node": "18.11.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@bytescale/upload-widget-react": "^4.1.0",
+    "@bytescale/upload-widget-react": "^4.9.0",
     "@headlessui/react": "^1.7.7",
     "@headlessui/tailwindcss": "^0.1.2",
     "@heroicons/react": "^2.0.16",


### PR DESCRIPTION
Hey @Nutlope 👋

We've renamed our packages and improved Bytescale's SDKs.

This PR includes the latest and greatest.

Changes in this PR:

- 👉 Migrate `react-uploader` -> `@bytescale/upload-widget-react` (see: [`MIGRATE.md`](https://github.com/bytescale/bytescale-upload-widget-react/blob/main/MIGRATE.md))
- 👉 Use `Bytescale.UrlBuilder` instead of `String.replace`.

Benefits:

- ✅  Simpler code (no more `Uploader` instance: it's all simply props on `UploadDropzone` now).
- ✅  Safer URL creation by using `UrlBuilder` (as `replace` could in theory modify the user's account ID in the URL).
- ✅  Better type hints re. URL parameter options, which come from the `UrlBuilder`.
- ✅  Better support for [Next.js edge runtimes](https://github.com/bytescale/bytescale-javascript-sdk/blob/main/package.json#L16-L19) in the core Bytescale JavaScript SDK.
- ✅  Support & bug fixes: `react-uploader` won't be receiving updates, whereas `@bytescale/upload-widget-react` will.